### PR TITLE
fix: [BUG] Undefined property: stdClass::$family_name

### DIFF
--- a/src/Libraries/GoogleOAuth.php
+++ b/src/Libraries/GoogleOAuth.php
@@ -96,7 +96,7 @@ class GoogleOAuth extends AbstractOAuth
         if ($nameOfProcess === 'syncingUserInfo') {
             return [
                 $this->config->usersColumnsName['first_name'] => $userInfo->name,
-                $this->config->usersColumnsName['last_name']  => $userInfo->family_name,
+                $this->config->usersColumnsName['last_name']  => $userInfo->family_name ?? null,
                 $this->config->usersColumnsName['avatar']     => $userInfo->picture,
             ];
         }


### PR DESCRIPTION
Some users leave their last name blank when creating a google account especially old users, so I added a little condition to avoid exception errors